### PR TITLE
Omit fields from schema that are marked to be explicitly skipped.

### DIFF
--- a/zod.go
+++ b/zod.go
@@ -288,6 +288,11 @@ func (c *Converter) ConvertType(t reflect.Type, name string, indent int) string 
 func (c *Converter) convertField(f reflect.StructField, indent int, optional, nullable bool) string {
 	name := fieldName(f)
 
+	// fields named `-` are not exported to JSON so don't export zod types
+	if name == "-" {
+		return ""
+	}
+
 	// because nullability is processed before custom types, this makes sure
 	// the custom type has control over nullability.
 	fullName, _ := getFullName(f.Type)

--- a/zod_test.go
+++ b/zod_test.go
@@ -76,6 +76,25 @@ export type User = z.infer<typeof UserSchema>
 		StructToZodSchema(User{}))
 }
 
+func TestStructSimpleWithOmittedField(t *testing.T) {
+	type User struct {
+		Name        string
+		Age         int
+		Height      float64
+		NotExported string `json:"-"`
+	}
+	assert.Equal(t,
+		`export const UserSchema = z.object({
+  Name: z.string(),
+  Age: z.number(),
+  Height: z.number(),
+})
+export type User = z.infer<typeof UserSchema>
+
+`,
+		StructToZodSchema(User{}))
+}
+
 func TestStructSimplePrefix(t *testing.T) {
 	type User struct {
 		Name   string


### PR DESCRIPTION
Struct fields in Go can be annotated with `json:"-"` to be omitted from the JSON representation. Because these fields are omitted upon converting to JSON, they should also be omitted from the zod schema.