### PR TITLE
Fix ordering

### DIFF
--- a/zod.go
+++ b/zod.go
@@ -130,9 +130,13 @@ type Converter struct {
 }
 
 func (c *Converter) addSchema(name string, data string) {
-	order := c.structs
-	c.outputs[name] = entry{order, data}
-	c.structs = order + 1
+	//First check if the object already exists. If it does do not replace. This is needed for second order
+	_, ok := c.outputs[name]
+	if !ok {
+		order := c.structs
+		c.outputs[name] = entry{order, data}
+		c.structs = order + 1
+	}
 }
 
 func schemaName(prefix, name string) string {

--- a/zod_test.go
+++ b/zod_test.go
@@ -358,14 +358,21 @@ export type User = z.infer<typeof UserSchema>
 }
 
 func TestEverything(t *testing.T) {
+	// The order matters PostWithMetaData needs to be declared after post otherwise it will raise a
+	// `Block-scoped variable 'Post' used before its declaration.` typescript error.
 	type Post struct {
 		Title string
+	}
+	type PostWithMetaData struct {
+		Title string
+		Post  Post
 	}
 	type User struct {
 		Name                 string
 		Nickname             *string // pointers become optional
 		Age                  int
 		Height               float64
+		OldPostWithMetaData  PostWithMetaData
 		Tags                 []string
 		TagsOptional         []string   `json:",omitempty"` // slices with omitempty cannot be null
 		TagsOptionalNullable *[]string  `json:",omitempty"` // pointers to slices with omitempty can be null or undefined
@@ -384,6 +391,8 @@ func TestEverything(t *testing.T) {
 		ExtendedPropsNullable         *interface{}       // pointers to interfaces are just "any"
 		ExtendedPropsOptionalNullable *interface{}       `json:",omitempty"` // pointers to interfaces with omitempty are also just "any"
 		ExtendedPropsVeryIndirect     ****interface{}    // interfaces are always "any" no matter the levels of indirection
+		NewPostWithMetaData           PostWithMetaData
+		VeryNewPost                   Post
 	}
 	assert.Equal(t,
 		`export const PostSchema = z.object({
@@ -391,11 +400,18 @@ func TestEverything(t *testing.T) {
 })
 export type Post = z.infer<typeof PostSchema>
 
+export const PostWithMetaDataSchema = z.object({
+  Title: z.string(),
+  Post: PostSchema,
+})
+export type PostWithMetaData = z.infer<typeof PostWithMetaDataSchema>
+
 export const UserSchema = z.object({
   Name: z.string(),
   Nickname: z.string().nullable(),
   Age: z.number(),
   Height: z.number(),
+  OldPostWithMetaData: PostWithMetaDataSchema,
   Tags: z.string().array().nullable(),
   TagsOptional: z.string().array().optional(),
   TagsOptionalNullable: z.string().array().optional().nullable(),
@@ -414,6 +430,8 @@ export const UserSchema = z.object({
   ExtendedPropsNullable: z.any(),
   ExtendedPropsOptionalNullable: z.any(),
   ExtendedPropsVeryIndirect: z.any(),
+  NewPostWithMetaData: PostWithMetaDataSchema,
+  VeryNewPost: PostSchema,
 })
 export type User = z.infer<typeof UserSchema>
 


### PR DESCRIPTION
There was a issue where if you had a struct being called in a sub struct and in the top struct level, and that being after all the others it was causing a typescript issue. 

I have extended the testEverything to include the edge case. Without my fix the output would be 
```
assert.Equal(t,
		`export const PostWithMetaDataSchema = z.object({
  Title: z.string(),
  Post: PostSchema,
})
export type PostWithMetaData = z.infer<typeof PostWithMetaDataSchema>

export const PostSchema = z.object({
  Title: z.string(),
})
export type Post = z.infer<typeof PostSchema>

export const UserSchema = z.object({
  Name: z.string(),
  Nickname: z.string().nullable(),
  Age: z.number(),
  Height: z.number(),
  OldPostWithMetaData: PostWithMetaDataSchema,
  Tags: z.string().array().nullable(),
  TagsOptional: z.string().array().optional(),
  TagsOptionalNullable: z.string().array().optional().nullable(),
  Favourites: z.object({
    Name: z.string(),
  }).array().nullable(),
  Posts: PostSchema.array().nullable(),
  Post: PostSchema,
  PostOptional: PostSchema.optional(),
  PostOptionalNullable: PostSchema.optional().nullable(),
  Metadata: z.record(z.string(), z.string()).nullable(),
  MetadataOptional: z.record(z.string(), z.string()).optional(),
  MetadataOptionalNullable: z.record(z.string(), z.string()).optional().nullable(),
  ExtendedProps: z.any(),
  ExtendedPropsOptional: z.any(),
  ExtendedPropsNullable: z.any(),
  ExtendedPropsOptionalNullable: z.any(),
  ExtendedPropsVeryIndirect: z.any(),
  NewPostWithMetaData: PostWithMetaDataSchema,
  VeryNewPost: PostSchema,
})
export type User = z.infer<typeof UserSchema>

`, StructToZodSchema(User{}))
}
```

This would cause a typescript error `Block-scoped variable 'Post' used before its declaration.` typescript error as PostWithMetaDataSchema  is being used before the declaration of the object. 