### PR TITLE
Create function to convert a slice of objects

### DIFF
--- a/custom/optional/optional.go
+++ b/custom/optional/optional.go
@@ -10,6 +10,6 @@ import (
 var (
 	OptionalType = "4d63.com/optional.Optional"
 	OptionalFunc = func(c *supervillain.Converter, t reflect.Type, s string, g string, i int) string {
-		return fmt.Sprintf("%s.optional()", c.ConvertType(t.Elem(), s, i))
+		return fmt.Sprintf("%s.optional().nullish()", c.ConvertType(t.Elem(), s, i))
 	}
 )

--- a/zod.go
+++ b/zod.go
@@ -38,6 +38,26 @@ func (c *Converter) Convert(input interface{}) string {
 	return output.String()
 }
 
+func (c *Converter) ConvertSlice(inputs []interface{}) string {
+	for _, input := range inputs {
+		t := reflect.TypeOf(input)
+		c.addSchema(t.Name(), c.convertStructTopLevel(t))
+	}
+	output := strings.Builder{}
+	sorted := []entry{}
+	for _, ent := range c.outputs {
+		sorted = append(sorted, ent)
+	}
+
+	sort.Sort(ByOrder(sorted))
+
+	for _, ent := range sorted {
+		output.WriteString(ent.data)
+		output.WriteString("\n\n")
+	}
+	return output.String()
+}
+
 func StructToZodSchema(input interface{}) string {
 	c := Converter{
 		prefix:  "",

--- a/zod_test.go
+++ b/zod_test.go
@@ -294,6 +294,46 @@ export type User = z.infer<typeof UserSchema>
 `, StructToZodSchema(User{}))
 }
 
+func TestConvertSlice(t *testing.T) {
+	type Foo struct {
+		Bar string
+		Baz string
+		Quz string
+	}
+
+	type Zip struct {
+		Zap *Foo
+	}
+
+	type Whim struct {
+		Wham *Foo
+	}
+	c := NewConverter(map[string]CustomFn{})
+	types := []interface{}{
+		Zip{},
+		Whim{},
+	}
+	assert.Equal(t,
+		`export const ZipSchema = z.object({
+  Zap: FooSchema.nullable(),
+})
+export type Zip = z.infer<typeof ZipSchema>
+
+export const FooSchema = z.object({
+  Bar: z.string(),
+  Baz: z.string(),
+  Quz: z.string(),
+})
+export type Foo = z.infer<typeof FooSchema>
+
+export const WhimSchema = z.object({
+  Wham: FooSchema.nullable(),
+})
+export type Whim = z.infer<typeof WhimSchema>
+
+`, c.ConvertSlice(types))
+}
+
 func TestStructTime(t *testing.T) {
 	type User struct {
 		Name string


### PR DESCRIPTION
Right now, if we want to generate a bunch of types, and output them to the same file, if any of them share dependencies then we'll generate them twice.

So here's a function that uses the same converter to handle a list of types.