### PR TITLE
Accept custom schemas via a ZodSchema() method

### DIFF
--- a/custom/set/set.go
+++ b/custom/set/set.go
@@ -1,0 +1,23 @@
+package set
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/Southclaws/supervillain"
+)
+
+type Set[T comparable] map[T]struct{}
+
+func (s Set[T]) MarshalJSON() ([]byte, error) {
+	keys := make([]T, 0, len(s))
+	for k := range s {
+		keys = append(keys, k)
+	}
+	return json.Marshal(keys)
+}
+
+func (s Set[T]) ZodSchema(c *supervillain.Converter, t reflect.Type, name, generic string, indent int) string {
+	return fmt.Sprintf("%s.array()", c.ConvertType(t.Key(), name, indent))
+}

--- a/custom/set/set_test.go
+++ b/custom/set/set_test.go
@@ -1,0 +1,25 @@
+package set_test
+
+import (
+	"testing"
+
+	"github.com/Southclaws/supervillain"
+	"github.com/Southclaws/supervillain/custom/set"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSet(t *testing.T) {
+	type User struct {
+		Nicknames       set.Set[string]
+		FavoriteNumbers set.Set[int]
+	}
+	assert.Equal(t,
+		`export const UserSchema = z.object({
+  Nicknames: z.string().array(),
+  FavoriteNumbers: z.number().array(),
+})
+export type User = z.infer<typeof UserSchema>
+
+`,
+		supervillain.StructToZodSchema(User{}))
+}

--- a/custom/state/state.go
+++ b/custom/state/state.go
@@ -1,0 +1,53 @@
+package state
+
+import "encoding/json"
+
+type State int
+
+const (
+	StateUnknown    State = 0
+	StateProcessing State = 1
+	StateSuccess    State = 2
+	StateFailed     State = 3
+)
+
+const (
+	StateStringUnknown    = "unknown"
+	StateStringProcessing = "processing"
+	StateStringSuccess    = "success"
+	StateStringFailed     = "failed"
+)
+
+func (s State) String() string {
+	switch s {
+	case StateProcessing:
+		return StateStringProcessing
+	case StateSuccess:
+		return StateStringSuccess
+	case StateFailed:
+		return StateStringFailed
+	default:
+		return StateStringUnknown
+	}
+}
+
+func ParseState(s string) State {
+	switch s {
+	case StateStringProcessing:
+		return StateProcessing
+	case StateStringSuccess:
+		return StateSuccess
+	case StateStringFailed:
+		return StateFailed
+	default:
+		return StateUnknown
+	}
+}
+
+func (s State) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+func (s State) ZodSchema() string {
+	return "z.string()"
+}

--- a/custom/state/state_test.go
+++ b/custom/state/state_test.go
@@ -1,0 +1,23 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/Southclaws/supervillain"
+	"github.com/Southclaws/supervillain/custom/state"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestState(t *testing.T) {
+	type Job struct {
+		State state.State
+	}
+	assert.Equal(t,
+		`export const JobSchema = z.object({
+  State: z.string(),
+})
+export type Job = z.infer<typeof JobSchema>
+
+`,
+		supervillain.StructToZodSchema(Job{}))
+}


### PR DESCRIPTION
Passing a centralized map of custom schema functions to `NewConverter()` separates the custom schema definition from its type. Sometimes this is necessary (as in the `shopspring/decimal.Decimal` example), but when the supervillain user has control over the type that needs a custom schema, it's nicer to define a method that returns the schema.

New examples are included in the custom/ directory.