### PR TITLE
Treat byte slices as strings

### DIFF
--- a/zod.go
+++ b/zod.go
@@ -368,6 +368,12 @@ func (c *Converter) ConvertType(t reflect.Type, name string, indent int) string 
 	}
 
 	if t.Kind() == reflect.Slice {
+		if t.Elem().Kind() == reflect.Uint8 {
+			// Per https://pkg.go.dev/encoding/json#Marshal, []byte is marshalled as a
+			// base64-encoded string.
+			return "z.string()"
+		}
+
 		return fmt.Sprintf(
 			"%s.array()",
 			c.ConvertType(t.Elem(), name, indent))

--- a/zod_test.go
+++ b/zod_test.go
@@ -263,6 +263,20 @@ export type User = z.infer<typeof UserSchema>
 		StructToZodSchema(User{}))
 }
 
+func TestBytes(t *testing.T) {
+	type Message struct {
+		Data []byte
+	}
+	assert.Equal(t,
+		`export const MessageSchema = z.object({
+  Data: z.string().nullable(),
+})
+export type Message = z.infer<typeof MessageSchema>
+
+`,
+		StructToZodSchema(Message{}))
+}
+
 func TestInterfaceAny(t *testing.T) {
 	type User struct {
 		Name     string


### PR DESCRIPTION
This is a special case noted in the json.Marshal() documentation
(https://pkg.go.dev/encoding/json#Marshal):

> Array and slice values encode as JSON arrays, except that []byte
> encodes as a base64-encoded string, and a nil slice encodes as the
> null JSON value.