### PR TITLE
Allow dropping of duplicated fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,44 @@ export type User = z.infer<typeof UserSchema>;
 
 ## Custom Types
 
+### Skipping fields
+
+If a field is present in an
+[embedded struct](https://gobyexample.com/struct-embedding) tagged with
+`inline`, and subsequently "redeclared" with the same JSON tag prefixed with
+`-`, the embedded field will be omitted.
+
+```go
+package main
+
+import (
+	"fmt"
+)
+
+type BaseType struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Start int    `json:"start"`
+	End   int    `json:"end"`
+}
+
+type FinalType struct {
+	BaseType `json:",inline"`
+	Start    int `json:"-start"`
+	End      int `json:"-end"`
+}
+
+func main() {
+	fmt.Println(StructToZodSchema(FinalType{}))
+
+	// export const FinalTypeSchema = z.object({
+	//   id: z.string(),
+	//   name: z.string(),
+	// })
+	// export type FinalType = z.infer<typeof FinalTypeSchema>
+}
+```
+
 ### ZodSchema() method
 
 You can define a custom conversion using a `ZodSchema()` method. This should have one of the following types:

--- a/README.md
+++ b/README.md
@@ -51,10 +51,8 @@ export type User = z.infer<typeof UserSchema>;
 
 ### Skipping fields
 
-If a field is present in an
-[embedded struct](https://gobyexample.com/struct-embedding) tagged with
-`inline`, and subsequently "redeclared" with the same JSON tag prefixed with
-`-`, the embedded field will be omitted.
+If a field is declared with a JSON tag prefixed with `-`, and subsequently also
+present inside an `inline`d struct, the embedded field will be omitted.
 
 ```go
 package main
@@ -71,9 +69,9 @@ type BaseType struct {
 }
 
 type FinalType struct {
-	BaseType `json:",inline"`
 	Start    int `json:"-start"`
 	End      int `json:"-end"`
+	BaseType `json:",inline"`
 }
 
 func main() {

--- a/zod.go
+++ b/zod.go
@@ -3,8 +3,10 @@ package supervillain
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 )

--- a/zod_test.go
+++ b/zod_test.go
@@ -876,6 +876,30 @@ export type BaseStruct = z.infer<typeof BaseStructSchema>
 `, StructToZodSchema(BaseStruct{}))
 }
 
+func TestSkipFields(t *testing.T) {
+	type BaseType struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Start int    `json:"start"`
+		End   int    `json:"end"`
+	}
+
+	type FinalType struct {
+		Start    int `json:"-start"`
+		End      int `json:"-end"`
+		BaseType `    json:",inline"`
+	}
+
+	assert.Equal(t,
+		`export const FinalTypeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+})
+export type FinalType = z.infer<typeof FinalTypeSchema>
+
+`, StructToZodSchema(FinalType{}))
+}
+
 func TestDuplicatedInlineStructs(t *testing.T) {
 	type Struct struct {
 		Field string `json:"field"`

--- a/zod_test.go
+++ b/zod_test.go
@@ -884,20 +884,39 @@ func TestSkipFields(t *testing.T) {
 		End   int    `json:"end"`
 	}
 
-	type FinalType struct {
+	// fields to be skipped must be declared before the embedded type
+
+	type FieldsSkipped struct {
 		Start    int `json:"-start"`
 		End      int `json:"-end"`
 		BaseType `    json:",inline"`
 	}
 
 	assert.Equal(t,
-		`export const FinalTypeSchema = z.object({
+		`export const FieldsSkippedSchema = z.object({
   id: z.string(),
   name: z.string(),
 })
-export type FinalType = z.infer<typeof FinalTypeSchema>
+export type FieldsSkipped = z.infer<typeof FieldsSkippedSchema>
 
-`, StructToZodSchema(FinalType{}))
+`, StructToZodSchema(FieldsSkipped{}))
+
+	type FieldsNotSkipped struct {
+		BaseType `    json:",inline"`
+		Start    int `json:"-start"`
+		End      int `json:"-end"`
+	}
+
+	assert.Equal(t,
+		`export const FieldsNotSkippedSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  start: z.number(),
+  end: z.number(),
+})
+export type FieldsNotSkipped = z.infer<typeof FieldsNotSkippedSchema>
+
+`, StructToZodSchema(FieldsNotSkipped{}))
 }
 
 func TestDuplicatedInlineStructs(t *testing.T) {


### PR DESCRIPTION
At my workplace, we are experimenting with this package to convert our internal
Go types into user-facing TypeScript types, and this has saved us a lot of
manual effort thus far, so thank you for your work.
One thing we have noticed was that we generally use struct embedding to reshape
our internal types into something structurally different, in the process
removing one or more embedded fields from end users.
In order to achieve this internal/external dichotomy with `supervillain`, our
current approach requires us to explicitly declare a copy of the internal type
with _mostly_ the same fields, then remove some of them.
This is somewhat tedious and repetitive, since our structs can get rather long.

```go
type BaseType struct {
	ID    string `json:"id"`
	Name  string `json:"name"`
	Start int    `json:"start"` // we want to omit only Start and End
	End   int    `json:"end"`
    // more fields...
}

type FinalType struct {
	ID    string `json:"id"`
	Name  string `json:"name"`
    // more fields...
}
```

This PR makes it possible to drop an embedded field by first duplicating a field
and prefixing the field's tag with `-`.
To achieve this, we modify the recursive algorithm in `convertStructFields` to
maintain the necessary state during recursion.

```go
type BaseType struct {
	ID    string `json:"id"`
	Name  string `json:"name"`
	Start int    `json:"start"`
	End   int    `json:"end"`
    // more fields...
}

type FinalType struct {
	Start    int `json:"-start"`
	End      int `json:"-end"`
	BaseType `json:",inline"`
}

// export const FinalTypeSchema = z.object({
//   id: z.string(),
//   name: z.string(),
// })
// export type FinalType = z.infer<typeof FinalTypeSchema>
```
